### PR TITLE
VCST-2774: change white labeling resolving

### DIFF
--- a/src/VirtoCommerce.WhiteLabeling.Data/Services/WhiteLabelingSettingSearchService.cs
+++ b/src/VirtoCommerce.WhiteLabeling.Data/Services/WhiteLabelingSettingSearchService.cs
@@ -29,15 +29,19 @@ namespace VirtoCommerce.WhiteLabeling.Data.Services
                 query = query.Where(x => x.IsEnabled == criteria.IsEnabled.Value);
             }
 
+            var predicate = PredicateBuilder.False<WhiteLabelingSettingEntity>();
+
             if (!string.IsNullOrEmpty(criteria.OrganizationId))
             {
-                query = query.Where(x => x.OrganizationId == criteria.OrganizationId);
+                predicate = predicate.Or(x => x.OrganizationId == criteria.OrganizationId);
             }
 
             if (!string.IsNullOrEmpty(criteria.StoreId))
             {
-                query = query.Where(x => x.StoreId == criteria.StoreId);
+                predicate = predicate.Or(x => x.StoreId == criteria.StoreId);
             }
+
+            query = query.Where(predicate);
 
             return query;
         }

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Commands/ChangeOrganizationLogoCommand.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Commands/ChangeOrganizationLogoCommand.cs
@@ -16,6 +16,6 @@ public class InputChangeOrganizationLogoCommandType : InputObjectGraphType<Chang
     public InputChangeOrganizationLogoCommandType()
     {
         Field(x => x.OrganizationId, nullable: false);
-        Field(x => x.LogoUrl, nullable: false);
+        Field(x => x.LogoUrl, nullable: true);
     }
 }

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Commands/ChangeOrganizationLogoCommandHandler.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Commands/ChangeOrganizationLogoCommandHandler.cs
@@ -44,16 +44,23 @@ public class ChangeOrganizationLogoCommandHandler : IRequestHandler<ChangeOrgani
             whiteLabelingSetting.IsEnabled = true;
         }
 
-        var logoUrlFile = await UpdateLogoUrlFile(request);
-        if (logoUrlFile.Item1 == null)
+        if (!string.IsNullOrEmpty(request.LogoUrl))
         {
-            return new ChangeOrganizationLogoResult
+            var logoUrlFile = await UpdateLogoUrlFile(request);
+            if (logoUrlFile.Item1 == null)
             {
-                ErrorMessage = logoUrlFile.Item2?.FirstOrDefault()?.ErrorMessage
-            };
+                return new ChangeOrganizationLogoResult
+                {
+                    ErrorMessage = logoUrlFile.Item2?.FirstOrDefault()?.ErrorMessage
+                };
+            }
+            whiteLabelingSetting.LogoUrl = request.LogoUrl;
         }
-
-        whiteLabelingSetting.LogoUrl = request.LogoUrl;
+        else
+        {
+            await DeleteLogoUrlFile(whiteLabelingSetting);
+            whiteLabelingSetting.LogoUrl = null;
+        }
 
         await _whiteLabelingSettingService.SaveChangesAsync([whiteLabelingSetting]);
 
@@ -99,6 +106,13 @@ public class ChangeOrganizationLogoCommandHandler : IRequestHandler<ChangeOrgani
 
         return (file, null);
     }
+
+
+    protected virtual Task DeleteLogoUrlFile(WhiteLabelingSetting currentSettings)
+    {
+        return Task.FromResult<object>(null);
+    }
+
 
     protected static string GetFileId(string url)
     {

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQueryHandler.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQueryHandler.cs
@@ -124,7 +124,7 @@ namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Queries
             return searchResult.Results.ToArray();
         }
 
-        private WhiteLabelingSetting GetCombinedWhiteLabelingSetting(WhiteLabelingSettingResult result)
+        private static WhiteLabelingSetting GetCombinedWhiteLabelingSetting(WhiteLabelingSettingResult result)
         {
             return new WhiteLabelingSetting()
             {

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQueryHandler.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQueryHandler.cs
@@ -126,16 +126,26 @@ namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Queries
 
         private static WhiteLabelingSetting GetCombinedWhiteLabelingSetting(WhiteLabelingSettingResult result)
         {
+            if (result.StoreSetting == null)
+            {
+                return result.OrganizationSetting;
+            }
+
+            if (result.OrganizationSetting == null)
+            {
+                return result.StoreSetting;
+            }
+
             return new WhiteLabelingSetting()
             {
                 IsEnabled = true,
-                OrganizationId = result.OrganizationSetting?.OrganizationId,
-                StoreId = result.StoreSetting?.StoreId,
-                LogoUrl = !string.IsNullOrEmpty(result.OrganizationSetting?.LogoUrl) ? result.OrganizationSetting.LogoUrl : result.StoreSetting?.LogoUrl,
-                SecondaryLogoUrl = !string.IsNullOrEmpty(result.OrganizationSetting?.SecondaryLogoUrl) ? result.OrganizationSetting.SecondaryLogoUrl : result.StoreSetting?.SecondaryLogoUrl,
-                FaviconUrl = !string.IsNullOrEmpty(result.OrganizationSetting?.FaviconUrl) ? result.OrganizationSetting.FaviconUrl : result.StoreSetting?.FaviconUrl,
-                FooterLinkListName = !string.IsNullOrEmpty(result.OrganizationSetting?.FooterLinkListName) ? result.OrganizationSetting.FooterLinkListName : result.StoreSetting?.FooterLinkListName,
-                ThemePresetName = !string.IsNullOrEmpty(result.OrganizationSetting?.ThemePresetName) ? result.OrganizationSetting.ThemePresetName : result.StoreSetting?.ThemePresetName,
+                OrganizationId = result.OrganizationSetting.OrganizationId,
+                StoreId = result.StoreSetting.StoreId,
+                LogoUrl = !string.IsNullOrEmpty(result.OrganizationSetting.LogoUrl) ? result.OrganizationSetting.LogoUrl : result.StoreSetting.LogoUrl,
+                SecondaryLogoUrl = !string.IsNullOrEmpty(result.OrganizationSetting.SecondaryLogoUrl) ? result.OrganizationSetting.SecondaryLogoUrl : result.StoreSetting.SecondaryLogoUrl,
+                FaviconUrl = !string.IsNullOrEmpty(result.OrganizationSetting.FaviconUrl) ? result.OrganizationSetting.FaviconUrl : result.StoreSetting.FaviconUrl,
+                FooterLinkListName = !string.IsNullOrEmpty(result.OrganizationSetting.FooterLinkListName) ? result.OrganizationSetting.FooterLinkListName : result.StoreSetting.FooterLinkListName,
+                ThemePresetName = !string.IsNullOrEmpty(result.OrganizationSetting.ThemePresetName) ? result.OrganizationSetting.ThemePresetName : result.StoreSetting.ThemePresetName,
             };
         }
 


### PR DESCRIPTION
## Description
Change White labeling resolve behavior so that a query:
`whiteLabelingSettings(cultureName:"en-US", organizationId: "OrgID1", storeId:"StoreID1")`
will merge both whitelabeling entities from **organization** and the **store**. All null or empty **organization** whitelabeling properties will be substituted by **store's** whitelabeling.
## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/VCST-2774
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.WhiteLabeling_3.902.0-pr-11-32e4.zip