### PR TITLE
VCST-2896: add white labeling organization flags

### DIFF
--- a/src/VirtoCommerce.WhiteLabeling.Core/Models/WhiteLabelingSetting.cs
+++ b/src/VirtoCommerce.WhiteLabeling.Core/Models/WhiteLabelingSetting.cs
@@ -15,6 +15,10 @@ namespace VirtoCommerce.WhiteLabeling.Core.Models
         public string ThemePresetName { get; set; }
         public string StoreId { get; set; }
 
+        public bool IsOrganizationLogoUploaded { get; set; }
+        public bool IsOrganizationSecondaryLogoUploaded { get; set; }
+        public bool IsOrganizationFaviconUploaded { get; set; }
+
         public object Clone()
         {
             return MemberwiseClone();

--- a/src/VirtoCommerce.WhiteLabeling.Core/Models/WhiteLabelingSetting.cs
+++ b/src/VirtoCommerce.WhiteLabeling.Core/Models/WhiteLabelingSetting.cs
@@ -15,10 +15,6 @@ namespace VirtoCommerce.WhiteLabeling.Core.Models
         public string ThemePresetName { get; set; }
         public string StoreId { get; set; }
 
-        public bool IsOrganizationLogoUploaded { get; set; }
-        public bool IsOrganizationSecondaryLogoUploaded { get; set; }
-        public bool IsOrganizationFaviconUploaded { get; set; }
-
         public object Clone()
         {
             return MemberwiseClone();

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Models/ExpWhiteLabelingSetting.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Models/ExpWhiteLabelingSetting.cs
@@ -8,6 +8,8 @@ namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Models
     {
         public WhiteLabelingSetting LabelingSetting { get; set; }
 
+        public WhiteLabelingFlags LabelingFlags { get; set; }
+
         public IList<MenuItem> FooterLinks { get; set; } = [];
 
         public IList<ExpFavicon> Favicons { get; set; } = [];

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Models/WhiteLabelingFlags.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Models/WhiteLabelingFlags.cs
@@ -1,0 +1,9 @@
+namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Models;
+
+public class WhiteLabelingFlags
+{
+    public bool HasLogo { get; set; }
+    public bool HasSecondaryLogo { get; set; }
+    public bool HasFavicon { get; set; }
+}
+

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQueryHandler.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQueryHandler.cs
@@ -136,14 +136,21 @@ namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Queries
                 return result.StoreSetting;
             }
 
+            var isOrganizationLogoUploaded = !string.IsNullOrEmpty(result.OrganizationSetting.LogoUrl);
+            var isOrganizationSecondaryLogoUploaded = !string.IsNullOrEmpty(result.OrganizationSetting.SecondaryLogoUrl);
+            var isOrganizationFaviconUploaded = !string.IsNullOrEmpty(result.OrganizationSetting.FaviconUrl);
+
             return new WhiteLabelingSetting()
             {
                 IsEnabled = true,
                 OrganizationId = result.OrganizationSetting.OrganizationId,
                 StoreId = result.StoreSetting.StoreId,
-                LogoUrl = !string.IsNullOrEmpty(result.OrganizationSetting.LogoUrl) ? result.OrganizationSetting.LogoUrl : result.StoreSetting.LogoUrl,
-                SecondaryLogoUrl = !string.IsNullOrEmpty(result.OrganizationSetting.SecondaryLogoUrl) ? result.OrganizationSetting.SecondaryLogoUrl : result.StoreSetting.SecondaryLogoUrl,
-                FaviconUrl = !string.IsNullOrEmpty(result.OrganizationSetting.FaviconUrl) ? result.OrganizationSetting.FaviconUrl : result.StoreSetting.FaviconUrl,
+                IsOrganizationLogoUploaded = isOrganizationLogoUploaded,
+                LogoUrl = isOrganizationLogoUploaded ? result.OrganizationSetting.LogoUrl : result.StoreSetting.LogoUrl,
+                IsOrganizationSecondaryLogoUploaded = isOrganizationSecondaryLogoUploaded,
+                SecondaryLogoUrl = isOrganizationSecondaryLogoUploaded ? result.OrganizationSetting.SecondaryLogoUrl : result.StoreSetting.SecondaryLogoUrl,
+                IsOrganizationFaviconUploaded = isOrganizationFaviconUploaded,
+                FaviconUrl = isOrganizationFaviconUploaded ? result.OrganizationSetting.FaviconUrl : result.StoreSetting.FaviconUrl,
                 FooterLinkListName = !string.IsNullOrEmpty(result.OrganizationSetting.FooterLinkListName) ? result.OrganizationSetting.FooterLinkListName : result.StoreSetting.FooterLinkListName,
                 ThemePresetName = !string.IsNullOrEmpty(result.OrganizationSetting.ThemePresetName) ? result.OrganizationSetting.ThemePresetName : result.StoreSetting.ThemePresetName,
             };

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Schemas/WhiteLabelingSettingsType.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Schemas/WhiteLabelingSettingsType.cs
@@ -18,9 +18,15 @@ namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Schemas
             Field(x => x.LabelingSetting.ThemePresetName, nullable: true).Description("Theme preset name");
             Field<ListGraphType<MenuLinkType>>("footerLinks").Resolve(context => context.Source.FooterLinks);
             Field<ListGraphType<FaviconType>>("favicons").Resolve(context => context.Source.Favicons);
-            Field(x => x.LabelingSetting.IsOrganizationLogoUploaded, nullable: true).Description("If true then LogoUrl contains Organization logo");
-            Field(x => x.LabelingSetting.IsOrganizationSecondaryLogoUploaded, nullable: true).Description("If true then SecondaryLogoUrl contains Organization logo");
-            Field(x => x.LabelingSetting.IsOrganizationFaviconUploaded, nullable: true).Description("If true then FaviconUrl contains Organization favicon");
+
+            Field<BooleanGraphType>("IsOrganizationLogoUploaded").Resolve(context => context.Source.LabelingFlags?.HasLogo ?? false)
+                .Description("If true then LogoUrl contains Organization logo");
+
+            Field<BooleanGraphType>("IsOrganizationSecondaryLogoUploaded").Resolve(context => context.Source.LabelingFlags?.HasSecondaryLogo ?? false)
+                .Description("If true then SecondaryLogoUrl contains Organization logo");
+
+            Field<BooleanGraphType>("IsOrganizationFaviconUploaded").Resolve(context => context.Source.LabelingFlags?.HasFavicon ?? false)
+                .Description("If true then FaviconUrl contains Organization favicon");
         }
     }
 }

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Schemas/WhiteLabelingSettingsType.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Schemas/WhiteLabelingSettingsType.cs
@@ -18,6 +18,9 @@ namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Schemas
             Field(x => x.LabelingSetting.ThemePresetName, nullable: true).Description("Theme preset name");
             Field<ListGraphType<MenuLinkType>>("footerLinks").Resolve(context => context.Source.FooterLinks);
             Field<ListGraphType<FaviconType>>("favicons").Resolve(context => context.Source.Favicons);
+            Field(x => x.LabelingSetting.IsOrganizationLogoUploaded, nullable: true).Description("If true then LogoUrl contains Organization logo");
+            Field(x => x.LabelingSetting.IsOrganizationSecondaryLogoUploaded, nullable: true).Description("If true then SecondaryLogoUrl contains Organization logo");
+            Field(x => x.LabelingSetting.IsOrganizationFaviconUploaded, nullable: true).Description("If true then FaviconUrl contains Organization favicon");
         }
     }
 }


### PR DESCRIPTION
## Description

Added `isOrganizationLogoUploaded`, `isOrganizationSecondaryLogoUploaded` and `isOrganizationFaviconUploaded` flags:

```graphql
query whitelabeling {
  whiteLabelingSettings(organizationId: "123", storeId: "B2B-store") {
    logoUrl
    isOrganizationLogoUploaded
    secondaryLogoUrl
    isOrganizationSecondaryLogoUploaded
    faviconUrl
    isOrganizationFaviconUploaded
  }
}
```


## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-2896
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.WhiteLabeling_3.905.0-pr-15-a3c6.zip