### PR TITLE
VCST-3259: Add Domain argument to WhiteLabeling query

### DIFF
--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQuery.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQuery.cs
@@ -3,6 +3,7 @@ using GraphQL;
 using GraphQL.Types;
 using VirtoCommerce.WhiteLabeling.ExperienceApi.Models;
 using VirtoCommerce.Xapi.Core.BaseQueries;
+using VirtoCommerce.Xapi.Core.Extensions;
 
 namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Queries
 {
@@ -14,6 +15,8 @@ namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Queries
 
         public string StoreId { get; set; }
 
+        public string Domain { get; set; }
+
         public string CultureName { get; set; }
 
         public override IEnumerable<QueryArgument> GetArguments()
@@ -21,14 +24,16 @@ namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Queries
             yield return Argument<StringGraphType>(nameof(OrganizationId));
             yield return Argument<StringGraphType>(nameof(UserId));
             yield return Argument<StringGraphType>(nameof(StoreId));
+            yield return Argument<StringGraphType>(nameof(Domain));
             yield return Argument<StringGraphType>(nameof(CultureName));
         }
 
         public override void Map(IResolveFieldContext context)
         {
-            OrganizationId = context.GetArgument<string>(nameof(OrganizationId));
+            OrganizationId = context.GetArgument<string>(nameof(OrganizationId)) ?? context.GetCurrentOrganizationId();
             UserId = context.GetArgument<string>(nameof(UserId));
             StoreId = context.GetArgument<string>(nameof(StoreId));
+            Domain = context.GetArgument<string>(nameof(Domain));
             CultureName = context.GetArgument<string>(nameof(CultureName));
         }
     }

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/VirtoCommerce.WhiteLabeling.ExperienceApi.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/VirtoCommerce.WhiteLabeling.ExperienceApi.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Data" Version="3.903.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.914.0-alpha.91-vcst-3259" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.916.0" />
     <PackageReference Include="VirtoCommerce.XCMS.Core" Version="3.901.0" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.861.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/VirtoCommerce.WhiteLabeling.ExperienceApi.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/VirtoCommerce.WhiteLabeling.ExperienceApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Data" Version="3.903.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.904.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.914.0-alpha.91-vcst-3259" />
     <PackageReference Include="VirtoCommerce.XCMS.Core" Version="3.901.0" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.861.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
+++ b/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.861.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.903.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.914.0-alpha.91-vcst-3259" />
+    <dependency id="VirtoCommerce.Xapi" version="3.916.0" />
     <dependency id="VirtoCommerce.XCMS" version="3.901.0" />
     <dependency id="VirtoCommerce.Customer" version="3.811.0" />
     <dependency id="VirtoCommerce.ImageTools" version="3.802.0" />

--- a/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
+++ b/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.861.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.903.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.904.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.914.0-alpha.91-vcst-3259" />
     <dependency id="VirtoCommerce.XCMS" version="3.901.0" />
     <dependency id="VirtoCommerce.Customer" version="3.811.0" />
     <dependency id="VirtoCommerce.ImageTools" version="3.802.0" />


### PR DESCRIPTION
## Description
1. Added optional `domain` argument to `whiteLabelingSettings` query.
2. `storeId` argument is optional. Either one of two must be present.
3. `organizationId` argument is optional. Auto resolved from token info if not present.
## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/VCST-3259
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.WhiteLabeling_3.908.0-pr-17-0518.zip