### PR TITLE
VCST-4467: Add PageContext type hook

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.909.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>

--- a/src/VirtoCommerce.WhiteLabeling.Core/VirtoCommerce.WhiteLabeling.Core.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Core/VirtoCommerce.WhiteLabeling.Core.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.917.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.WhiteLabeling.Core/VirtoCommerce.WhiteLabeling.Core.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Core/VirtoCommerce.WhiteLabeling.Core.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.841.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.917.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.WhiteLabeling.Data.MySql/VirtoCommerce.WhiteLabeling.Data.MySql.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data.MySql/VirtoCommerce.WhiteLabeling.Data.MySql.csproj
@@ -9,7 +9,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11,9)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/VirtoCommerce.WhiteLabeling.Data.MySql/VirtoCommerce.WhiteLabeling.Data.MySql.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data.MySql/VirtoCommerce.WhiteLabeling.Data.MySql.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.841.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.917.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Data\VirtoCommerce.WhiteLabeling.Data.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.Data.MySql/VirtoCommerce.WhiteLabeling.Data.MySql.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data.MySql/VirtoCommerce.WhiteLabeling.Data.MySql.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <noWarn>NU1608</noWarn>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11,9)">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.917.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Data\VirtoCommerce.WhiteLabeling.Data.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.Data.PostgreSql/VirtoCommerce.WhiteLabeling.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data.PostgreSql/VirtoCommerce.WhiteLabeling.Data.PostgreSql.csproj
@@ -9,7 +9,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11,9)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/VirtoCommerce.WhiteLabeling.Data.PostgreSql/VirtoCommerce.WhiteLabeling.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data.PostgreSql/VirtoCommerce.WhiteLabeling.Data.PostgreSql.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.841.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.917.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Data\VirtoCommerce.WhiteLabeling.Data.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.Data.PostgreSql/VirtoCommerce.WhiteLabeling.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data.PostgreSql/VirtoCommerce.WhiteLabeling.Data.PostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -9,12 +9,12 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11,9)">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.917.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Data\VirtoCommerce.WhiteLabeling.Data.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.Data.SqlServer/VirtoCommerce.WhiteLabeling.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data.SqlServer/VirtoCommerce.WhiteLabeling.Data.SqlServer.csproj
@@ -9,7 +9,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11,9)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/VirtoCommerce.WhiteLabeling.Data.SqlServer/VirtoCommerce.WhiteLabeling.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data.SqlServer/VirtoCommerce.WhiteLabeling.Data.SqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -9,12 +9,12 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11,9)">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.917.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Data\VirtoCommerce.WhiteLabeling.Data.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.Data.SqlServer/VirtoCommerce.WhiteLabeling.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data.SqlServer/VirtoCommerce.WhiteLabeling.Data.SqlServer.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.841.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.917.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Data\VirtoCommerce.WhiteLabeling.Data.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.Data/VirtoCommerce.WhiteLabeling.Data.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data/VirtoCommerce.WhiteLabeling.Data.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.917.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Core\VirtoCommerce.WhiteLabeling.Core.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.Data/VirtoCommerce.WhiteLabeling.Data.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data/VirtoCommerce.WhiteLabeling.Data.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.841.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.917.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Core\VirtoCommerce.WhiteLabeling.Core.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/TypeHooks/PageContextHook.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/TypeHooks/PageContextHook.cs
@@ -1,0 +1,53 @@
+using GraphQL.Types;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using VirtoCommerce.WhiteLabeling.ExperienceApi.Queries;
+using VirtoCommerce.WhiteLabeling.ExperienceApi.Schemas;
+using VirtoCommerce.Xapi.Core.Helpers;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+using VirtoCommerce.XFrontend.Core.Models;
+using VirtoCommerce.XFrontend.Core.Schemas;
+
+namespace VirtoCommerce.WhiteLabeling.ExperienceApi.TypeHooks;
+
+public class PageContextHook : IGraphTypeHook
+{
+    public string TypeName { get; set; } = "PageContextResponseType";
+
+    public void BeforeTypeInitialized(IGraphType graphType)
+    {
+        if (graphType is PageContextResponseType pageContextResponseType)
+        {
+            var fieldAsync = FieldCreator.CreateFieldAsync<PageContextResponse, WhiteLabelingSettingsType>(
+              "whiteLabelingSettings",
+              "Gets white labeling settings for the current page context.",
+              resolve: async x =>
+              {
+                  if (x.Source == null)
+                  {
+                      return null;
+                  }
+
+                  var query = GetWhiteLabelingSettingQuery(x.Source);
+
+                  var mediator = x.RequestServices.GetRequiredService<IMediator>();
+                  var result = await mediator.Send(query);
+
+                  return result;
+              });
+
+            pageContextResponseType.AddField(fieldAsync);
+        }
+    }
+
+    protected virtual GetWhiteLabelingSettingsQuery GetWhiteLabelingSettingQuery(PageContextResponse response)
+    {
+        return new GetWhiteLabelingSettingsQuery
+        {
+            CultureName = response.CultureName,
+            OrganizationId = response.OrganizationId,
+            UserId = response.User?.Id,
+            StoreId = response.StoreResponse.StoreId,
+        };
+    }
+}

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/VirtoCommerce.WhiteLabeling.ExperienceApi.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/VirtoCommerce.WhiteLabeling.ExperienceApi.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.FileExperienceApi.Data" Version="3.903.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.930.0-alpha.139-vcst-4467" />
+    
+    <PackageReference Include="VirtoCommerce.FileExperienceApi.Data" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1002.0-alpha.146-vcst-4467" />
     <PackageReference Include="VirtoCommerce.XCMS.Core" Version="3.901.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.917.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
     <PackageReference Include="VirtoCommerce.XFrontend.Core" Version="3.803.0-alpha.18-vcst-4467" />
   
   </ItemGroup>

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/VirtoCommerce.WhiteLabeling.ExperienceApi.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/VirtoCommerce.WhiteLabeling.ExperienceApi.csproj
@@ -9,9 +9,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Data" Version="3.903.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.916.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.930.0-alpha.139-vcst-4467" />
     <PackageReference Include="VirtoCommerce.XCMS.Core" Version="3.901.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.861.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.917.0" />
+    <PackageReference Include="VirtoCommerce.XFrontend.Core" Version="3.803.0-alpha.18-vcst-4467" />
+  
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Core\VirtoCommerce.WhiteLabeling.Core.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.Web/Module.cs
+++ b/src/VirtoCommerce.WhiteLabeling.Web/Module.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using VirtoCommerce.FileExperienceApi.Core.Authorization;
+using VirtoCommerce.Platform.Core.Extensions;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Settings;
@@ -20,20 +21,30 @@ using VirtoCommerce.WhiteLabeling.Data.Services;
 using VirtoCommerce.WhiteLabeling.Data.SqlServer;
 using VirtoCommerce.WhiteLabeling.ExperienceApi;
 using VirtoCommerce.WhiteLabeling.ExperienceApi.Authorization;
+using VirtoCommerce.WhiteLabeling.ExperienceApi.TypeHooks;
 using VirtoCommerce.Xapi.Core.Extensions;
 
 namespace VirtoCommerce.WhiteLabeling.Web;
 
-public class Module : IModule, IHasConfiguration
+public class Module : IModule, IHasConfiguration, IHasModuleCatalog
 {
     public ManifestModuleInfo ModuleInfo { get; set; }
     public IConfiguration Configuration { get; set; }
+    public IModuleCatalog ModuleCatalog { get; set; }
+
+    // optional modules
+    private const string XFrontendModuleId = "VirtoCommerce.XFrontend";
 
     public void Initialize(IServiceCollection serviceCollection)
     {
         _ = new GraphQLBuilder(serviceCollection, builder =>
         {
             builder.AddSchema(serviceCollection, typeof(AssemblyMarker));
+
+            if (ModuleCatalog.IsModuleInstalled(XFrontendModuleId))
+            {
+                builder.AddGraphTypeHook<PageContextHook>();
+            }
         });
 
         serviceCollection.AddDbContext<WhiteLabelingDbContext>(options =>

--- a/src/VirtoCommerce.WhiteLabeling.Web/VirtoCommerce.WhiteLabeling.Web.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Web/VirtoCommerce.WhiteLabeling.Web.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <noWarn>NU1608</noWarn>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->

--- a/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
+++ b/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
@@ -7,10 +7,11 @@
   <platformVersion>3.861.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.903.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.916.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.930.0-alpha.139-vcst-4467" />
     <dependency id="VirtoCommerce.XCMS" version="3.901.0" />
     <dependency id="VirtoCommerce.Customer" version="3.811.0" />
     <dependency id="VirtoCommerce.ImageTools" version="3.802.0" />
+    <dependency id="VirtoCommerce.XFrontend" version="3.803.0-alpha.18-vcst-4467" optional="true" />
   </dependencies>
 
   <title>White Labeling</title>

--- a/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
+++ b/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.909.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.861.0</platformVersion>
+  <platformVersion>3.917.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.903.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.930.0-alpha.139-vcst-4467" />

--- a/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
+++ b/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
   <id>VirtoCommerce.WhiteLabeling</id>
-  <version>3.909.0</version>
+  <version>3.1000.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.917.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.FileExperienceApi" version="3.903.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.930.0-alpha.139-vcst-4467" />
+    <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1002.0-alpha.146-vcst-4467" />
     <dependency id="VirtoCommerce.XCMS" version="3.901.0" />
-    <dependency id="VirtoCommerce.Customer" version="3.811.0" />
-    <dependency id="VirtoCommerce.ImageTools" version="3.802.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
+    <dependency id="VirtoCommerce.ImageTools" version="3.1000.0" />
     <dependency id="VirtoCommerce.XFrontend" version="3.803.0-alpha.18-vcst-4467" optional="true" />
   </dependencies>
 

--- a/tests/VirtoCommerce.WhiteLabeling.Tests/VirtoCommerce.WhiteLabeling.Tests.csproj
+++ b/tests/VirtoCommerce.WhiteLabeling.Tests/VirtoCommerce.WhiteLabeling.Tests.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <noWarn>NU1608</noWarn>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is a test project -->
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.WhiteLabeling.Core\VirtoCommerce.WhiteLabeling.Core.csproj" />


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4467
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.WhiteLabeling_3.1000.0-pr-22-2066.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to the framework/runtime and dependency upgrades (to `net10.0`, EF 10, new XAPI/XFrontend versions) plus a schema extension that could affect GraphQL consumers when enabled.
> 
> **Overview**
> Adds a GraphQL type hook (`PageContextHook`) that extends `PageContextResponseType` with a `whiteLabelingSettings` field, resolved via MediatR using the current page context (store/org/user/culture).
> 
> Updates the module initialization to register this hook only when the optional `VirtoCommerce.XFrontend` module is installed, and bumps the module to `3.1000.0` while upgrading all projects to `net10.0` and aligning platform/XAPI/EF/test package dependencies to the `3.1002.x`/EF `10.0.1` line (plus `NU1608` suppression where needed).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20663b2fa309b9cc25f0c307d2517d81c44b24a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->