### PR TITLE
VCST-5468: Resolve mediators per request

### DIFF
--- a/src/VirtoCommerce.WhiteLabeling.Core/VirtoCommerce.WhiteLabeling.Core.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Core/VirtoCommerce.WhiteLabeling.Core.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.WhiteLabeling.Data.MySql/VirtoCommerce.WhiteLabeling.Data.MySql.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data.MySql/VirtoCommerce.WhiteLabeling.Data.MySql.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Data\VirtoCommerce.WhiteLabeling.Data.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.Data.PostgreSql/VirtoCommerce.WhiteLabeling.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data.PostgreSql/VirtoCommerce.WhiteLabeling.Data.PostgreSql.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Data\VirtoCommerce.WhiteLabeling.Data.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.Data.SqlServer/VirtoCommerce.WhiteLabeling.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data.SqlServer/VirtoCommerce.WhiteLabeling.Data.SqlServer.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Data\VirtoCommerce.WhiteLabeling.Data.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.Data/VirtoCommerce.WhiteLabeling.Data.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.Data/VirtoCommerce.WhiteLabeling.Data.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Core\VirtoCommerce.WhiteLabeling.Core.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Commands/ChangeOrganizationLogoCommandBuilder.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Commands/ChangeOrganizationLogoCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using MediatR;
@@ -17,10 +18,16 @@ public class ChangeOrganizationLogoCommandBuilder : CommandBuilder<ChangeOrganiz
 {
     protected override string Name => "ChangeOrganizationLogo";
 
+    public ChangeOrganizationLogoCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public ChangeOrganizationLogoCommandBuilder(
         IMediator mediator,
         IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQueryBuilder.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using VirtoCommerce.WhiteLabeling.ExperienceApi.Models;
@@ -8,8 +9,14 @@ namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Queries
 {
     public class GetWhiteLabelingSettingsQueryBuilder : QueryBuilder<GetWhiteLabelingSettingsQuery, ExpWhiteLabelingSetting, WhiteLabelingSettingsType>
     {
+        public GetWhiteLabelingSettingsQueryBuilder(IAuthorizationService authorizationService)
+            : base(authorizationService)
+        {
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         public GetWhiteLabelingSettingsQueryBuilder(IMediator mediator, IAuthorizationService authorizationService)
-            : base(mediator, authorizationService)
+            : this(authorizationService)
         {
         }
 

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/VirtoCommerce.WhiteLabeling.ExperienceApi.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/VirtoCommerce.WhiteLabeling.ExperienceApi.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Data" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
     <PackageReference Include="VirtoCommerce.XCMS.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WhiteLabeling.Core\VirtoCommerce.WhiteLabeling.Core.csproj" />

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/VirtoCommerce.WhiteLabeling.ExperienceApi.csproj
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/VirtoCommerce.WhiteLabeling.ExperienceApi.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Data" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
     <PackageReference Include="VirtoCommerce.XCMS.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
   </ItemGroup>

--- a/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
+++ b/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
@@ -7,9 +7,9 @@
   <platformVersion>3.1007.10</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1015.0" />
     <dependency id="VirtoCommerce.XCMS" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1010.0" />
     <dependency id="VirtoCommerce.ImageTools" version="3.1000.0" />
   </dependencies>
 

--- a/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
+++ b/src/VirtoCommerce.WhiteLabeling.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1003.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.1015.0" />


### PR DESCRIPTION
## Description

White Labeling GraphQL query and command builders are singleton schema components. Upgrade XApi to `3.1015.0` and use mediator-free constructors so dispatch is resolved from the active request scope.

Customer package and manifest dependency are aligned to `3.1010.0`, required by XApi 3.1015. Obsolete mediator constructors are retained for compatibility.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5468

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.WhiteLabeling_3.1003.0-alpha.90-vcst-5468.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request-scoped dispatch for GraphQL mutations/queries and bumps several platform dependency versions, which can affect runtime behavior during upgrades.
> 
> **Overview**
> Aligns White Labeling with **XApi 3.1015.0** and **Platform 3.1039.0** so GraphQL query/command builders no longer take a singleton-injected `IMediator`.
> 
> `ChangeOrganizationLogoCommandBuilder` and `GetWhiteLabelingSettingsQueryBuilder` now use constructors that only take `IAuthorizationService` and delegate to the updated XApi base types, which resolve **MediatR from `context.RequestServices` per request**. The previous `IMediator` constructors remain but are marked **`[Obsolete]`** (VC0015) for backward compatibility.
> 
> Package references and **`module.manifest`** are bumped accordingly, including **VirtoCommerce.Customer 3.1010.0** as required by the new XApi version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34d25aa3ef08f13d92515ae4ebd965f320957753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->