### PR TITLE
VCST-5575: Fixed blank storefront bug

### DIFF
--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQueryHandler.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQueryHandler.cs
@@ -239,7 +239,7 @@ namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Queries
             var extension = Path.GetExtension(fileName);
             var newName = string.Concat(name, "_" + aliasName, extension);
 
-            if (!Uri.TryCreate(fileName, UriKind.Absolute, out var uri))
+            if (!Uri.TryCreate(fileName, UriKind.Absolute, out var uri) || uri.Scheme is not ("http" or "https"))
             {
                 var lastSlashIndex = fileName.LastIndexOf('/');
                 return lastSlashIndex >= 0

--- a/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQueryHandler.cs
+++ b/src/VirtoCommerce.WhiteLabeling.ExperienceApi/Queries/GetWhiteLabelingSettingsQueryHandler.cs
@@ -66,12 +66,15 @@ namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Queries
             // add favicons
             if (!string.IsNullOrEmpty(whiteLabelingSetting.FaviconUrl))
             {
+                var extension = Path.GetExtension(whiteLabelingSetting.FaviconUrl);
+                var mimeType = extension.Length > 1 ? $"image/{extension[1..]}" : null;
+
                 foreach (var faviconSize in _faviconsSizes)
                 {
                     var newFavicon = new ExpFavicon()
                     {
                         Rel = "icon",
-                        Type = $"image/{Path.GetExtension(whiteLabelingSetting.FaviconUrl)[1..]}",
+                        Type = mimeType,
                         Sizes = faviconSize,
                         Href = GenerateFaviconName(whiteLabelingSetting.FaviconUrl, faviconSize),
                     };
@@ -236,7 +239,14 @@ namespace VirtoCommerce.WhiteLabeling.ExperienceApi.Queries
             var extension = Path.GetExtension(fileName);
             var newName = string.Concat(name, "_" + aliasName, extension);
 
-            var uri = new Uri(fileName);
+            if (!Uri.TryCreate(fileName, UriKind.Absolute, out var uri))
+            {
+                var lastSlashIndex = fileName.LastIndexOf('/');
+                return lastSlashIndex >= 0
+                    ? string.Concat(fileName.AsSpan(0, lastSlashIndex + 1), newName)
+                    : newName;
+            }
+
             var uriWithoutLastSegment = uri.AbsoluteUri.Remove(uri.AbsoluteUri.Length - uri.Segments.Last().Length);
 
             var result = new Uri(new Uri(uriWithoutLastSegment), newName);

--- a/tests/VirtoCommerce.WhiteLabeling.Tests/Handlers/GetWhiteLabelingSettingsQueryHandlerTests.cs
+++ b/tests/VirtoCommerce.WhiteLabeling.Tests/Handlers/GetWhiteLabelingSettingsQueryHandlerTests.cs
@@ -1,0 +1,88 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Moq;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.WhiteLabeling.Core.Models;
+using VirtoCommerce.WhiteLabeling.Core.Services;
+using VirtoCommerce.WhiteLabeling.ExperienceApi.Queries;
+using VirtoCommerce.Xapi.Core.Services;
+using Xunit;
+
+namespace VirtoCommerce.WhiteLabeling.Tests.Handlers
+{
+    [Trait("Category", "Unit")]
+    public class GetWhiteLabelingSettingsQueryHandlerTests
+    {
+        private readonly Mock<IWhiteLabelingSettingSearchService> _searchServiceMock = new();
+        private readonly Mock<IMemberService> _memberServiceMock = new();
+        private readonly Mock<IMediator> _mediatorMock = new();
+        private readonly Mock<IStoreDomainResolverService> _storeDomainResolverServiceMock = new();
+
+        [Fact]
+        public async Task Handle_FaviconUrlWithoutExtension_DoesNotThrow_AndOmitsMimeType()
+        {
+            // Arrange — malformed favicon URL with no file extension (e.g. bad data / imported via API)
+            SetupOrganizationSetting(new WhiteLabelingSetting
+            {
+                IsEnabled = true,
+                OrganizationId = "org-1",
+                FaviconUrl = "/api/files/does-not-exist-QA5519",
+            });
+
+            var handler = BuildHandler();
+            var query = new GetWhiteLabelingSettingsQuery { OrganizationId = "org-1", StoreId = "store-1" };
+
+            // Act
+            var result = await handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(5, result.Favicons.Count);
+            Assert.All(result.Favicons, favicon => Assert.Null(favicon.Type));
+
+            var favicon16 = result.Favicons.Single(x => x.Sizes == "16x16");
+            Assert.Equal("/api/files/does-not-exist-QA5519_16x16", favicon16.Href);
+        }
+
+        [Fact]
+        public async Task Handle_FaviconUrlWithExtension_GeneratesMimeTypeAndSizedHref()
+        {
+            // Arrange — regression check: well-formed favicon URL must keep working as before
+            SetupOrganizationSetting(new WhiteLabelingSetting
+            {
+                IsEnabled = true,
+                OrganizationId = "org-1",
+                FaviconUrl = "https://cdn.example.com/assets/favicon.png",
+            });
+
+            var handler = BuildHandler();
+            var query = new GetWhiteLabelingSettingsQuery { OrganizationId = "org-1", StoreId = "store-1" };
+
+            // Act
+            var result = await handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(5, result.Favicons.Count);
+            Assert.All(result.Favicons, favicon => Assert.Equal("image/png", favicon.Type));
+
+            var favicon16 = result.Favicons.Single(x => x.Sizes == "16x16");
+            Assert.Equal("https://cdn.example.com/assets/favicon_16x16.png", favicon16.Href);
+        }
+
+        private void SetupOrganizationSetting(WhiteLabelingSetting setting)
+        {
+            _searchServiceMock
+                .Setup(x => x.SearchAsync(It.IsAny<WhiteLabelingSettingSearchCriteria>(), It.IsAny<bool>()))
+                .ReturnsAsync(new WhiteLabelingSettingSearchResult { Results = [setting], TotalCount = 1 });
+
+            _memberServiceMock
+                .Setup(x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((Member)null);
+        }
+
+        private GetWhiteLabelingSettingsQueryHandler BuildHandler() =>
+            new(_searchServiceMock.Object, _memberServiceMock.Object, _mediatorMock.Object, _storeDomainResolverServiceMock.Object);
+    }
+}

--- a/tests/VirtoCommerce.WhiteLabeling.Tests/VirtoCommerce.WhiteLabeling.Tests.csproj
+++ b/tests/VirtoCommerce.WhiteLabeling.Tests/VirtoCommerce.WhiteLabeling.Tests.csproj
@@ -9,16 +9,18 @@
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.WhiteLabeling.Core\VirtoCommerce.WhiteLabeling.Core.csproj" />
+    <ProjectReference Include="..\..\src\VirtoCommerce.WhiteLabeling.ExperienceApi\VirtoCommerce.WhiteLabeling.ExperienceApi.csproj" />
     <ProjectReference Include="..\..\src\VirtoCommerce.WhiteLabeling.Web\VirtoCommerce.WhiteLabeling.Web.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description
Added defensive handling in GetWhiteLabelingSettingsQueryHandler for organization/store faviconUrl values that don't have a file extension or aren't absolute URLs. Previously, such values (e.g. set via API or imported bad data — the Admin UI upload widget always produces a valid extension) caused the whiteLabelingSettings GraphQL resolver to throw (ArgumentOutOfRangeException / UriFormatException), which cascaded into pageContext failing entirely and left the storefront blank for the affected org/store.

What's added

AddFaviconsAsync: MIME type (Type) is now computed once per favicon URL and safely omitted (null) when the URL has no file extension, instead of crashing on Path.GetExtension(...)[1..].
GenerateFaviconName: falls back to plain string concatenation for relative/non-absolute favicon URLs instead of crashing inside new Uri(fileName).
Unit tests (GetWhiteLabelingSettingsQueryHandlerTests) covering both the malformed-URL case (no exception, Type == null) and a regression case for well-formed absolute URLs (correct MIME type and sized href), following the existing Moq-based handler test convention from vc-module-profile-experience-api.
Test project now references VirtoCommerce.WhiteLabeling.ExperienceApi (previously untested) and adds a Moq package reference.
Breaking changes

None. This is a backward-compatible bug fix:

Valid favicon URLs (with extension, absolute) behave exactly as before.
The only behavior change is for the previously-crashing case: a favicon variant without a resolvable MIME type now gets Type: null in the GraphQL response instead of the whole pageContext query failing.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5575
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.WhiteLabeling_3.1004.0-pr-26-fdce.zip